### PR TITLE
Add IIP Support to OpenLime

### DIFF
--- a/dist/examples/iip-viewer/index.html
+++ b/dist/examples/iip-viewer/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OpenLIME - RTI Viewer</title>
+    <link rel="stylesheet" href="../../css/skin.css" />
+    <link rel="stylesheet" href="../examples.css" />
+
+    <script src="../../js/openlime.js"></script>
+
+  </head>
+
+  <body>
+    <h1>OpenLIME - IIPImage Viewer</h1>
+    <div class="openlime"></div>
+    <script>
+        // Create an OpenLIME canvas into openlime
+        const lime = new OpenLIME.Viewer('.openlime');
+
+        const layer0 = new OpenLIME.Layer({
+            layout: 'iip',
+            type: 'image',
+	    server: '/fcgi-bin/iipsrv.fcgi',
+            url: 'image.tif'
+        });
+        lime.addLayer('iip', layer0);
+	lime.camera.maxFixedZoom = 1;  // Disable zooming beyond 100%
+
+        // Fetch a skin (visual elements for the web page)
+        OpenLIME.Skin.setUrl('../../skin/skin.svg');
+
+        // Create an User Interface 
+        const ui = new OpenLIME.UIBasic(lime, {
+					attribution: "image credit",
+					enableTooltip: true });
+
+        // Customize our toolbar
+        ui.actions.layers.display = false;
+        ui.actions.light.display = false;
+        ui.actions.zoomin.display = true;
+        ui.actions.zoomout.display = true;
+        ui.actions.rotate.display = true;
+ 
+    </script>
+  </body>
+
+</html>

--- a/dist/examples/rti-stack-viewer/index.html
+++ b/dist/examples/rti-stack-viewer/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OpenLIME - RTI Viewer</title>
+    <link rel="stylesheet" href="../../css/skin.css" />
+    <link rel="stylesheet" href="../examples.css" />
+
+    <script src="../../js/openlime.js"></script>
+
+</head>
+
+<body>
+    <h1>OpenLIME - TIFF RTI Stack Viewer</h1>
+    <div class="openlime"></div>
+    <script>
+        // Create an OpenLIME canvas into openlime
+        const lime = new OpenLIME.Viewer('.openlime');
+
+        const layer0 = new OpenLIME.Layer({
+            label: 'TIFF RTI Stack',
+            layout: 'iip',
+            type: 'rti',
+	    server: '/fcgi-bin/iipsrv.fcgi',
+            url: 'RTI.tif',
+            normals: false
+        });
+        lime.addLayer('stack', layer0);
+
+        // Fetch a skin (visual elements for the web page)
+        OpenLIME.Skin.setUrl('../../skin/skin.svg');
+
+        // Create an User Interface 
+        const ui = new OpenLIME.UIBasic(lime, {showLightDirections: true, attribution: "RTI TIFF Stack"});
+
+        // Add zoomin and zoomout to the toolbar
+        ui.actions.zoomin.display = true;
+        ui.actions.zoomout.display = true;
+        ui.actions.light.active = true;
+
+        //ui.toggleLightController(true);
+ 
+    </script>
+</body>
+
+</html>

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -129,6 +129,7 @@ class Layer {
 
 		if (typeof (this.layout) == 'string') {
 			let size = { width: this.width, height: this.height };
+			if (this.server) size.server = this.server;
 			this.setLayout(new Layout(null, this.layout, size));
 		} else {
 			this.setLayout(this.layout);

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -111,6 +111,7 @@ class Layer {
 			height: 0,
 			prefetchBorder: 1,
 			mipmapBias: 0.4,
+			pixelSize: 0.0,
 
 			//signals: { update: [], ready: [], updateSize: [] },  //update callbacks for a redraw, ready once layout is known.
 
@@ -313,6 +314,16 @@ class Layer {
 		// FIXME: this do not consider children layers
 		return this.transform.z;
 	}
+
+
+	/**
+	* Transform-adjusted spatial resolution for this layer
+	* @return {number} size of a single pixel in mm
+	*/
+	pixelSizePerMM() {
+		return this.pixelSize * this.transform.z;
+	}
+
 
 	/**
 	 * Gets the layer bounding box (<FIXME> Change name: box is in scene coordinates)

--- a/src/ScaleBar.js
+++ b/src/ScaleBar.js
@@ -6,7 +6,7 @@ import { Util } from './Util'
 class Units {
     constructor(options) {
         this.units = ["km", "m", "cm", "mm", "µm"],
-        this.allUnits = { "µm": 0.001, ""mm": 1, "cm": 10, "m": 1000, "km": 1e6, "in": 254, "ft": 254*12 }
+        this.allUnits = { "µm": 0.001, "mm": 1, "cm": 10, "m": 1000, "km": 1e6, "in": 254, "ft": 254*12 }
         this.precision = 2;
         if(options)
             Object.assign(options, this);

--- a/src/ScaleBar.js
+++ b/src/ScaleBar.js
@@ -5,8 +5,8 @@ import { Util } from './Util'
 
 class Units {
     constructor(options) {
-        this.units = ["km", "m", "cm", "mm"],
-        this.allUnits = { "mm": 1, "cm": 10, "m": 1000, "km": 1e6, "in": 254, "ft": 254*12,  }
+        this.units = ["km", "m", "cm", "mm", "µm"],
+        this.allUnits = { "µm": 0.001, ""mm": 1, "cm": 10, "m": 1000, "km": 1e6, "in": 254, "ft": 254*12 }
         this.precision = 2;
         if(options)
             Object.assign(options, this);
@@ -17,7 +17,7 @@ class Units {
 			return '';
         if(unit)
             return (d/this.allUnits[unit]).toFixed(this.precision) + unit;
-        
+
         let best_u = null;
         let best_penalty = 100;
         for(let u of this.units) {
@@ -40,7 +40,7 @@ class ScaleBar extends Units {
             viewer: viewer,
             width: 200,
             fontSize: 24,
-			precision: 0
+            precision: 0
         }, options);
 		Object.assign(this, options);
 
@@ -51,7 +51,7 @@ class ScaleBar extends Units {
 
 		this.text = Util.createSVGElement('text', { x: '50%', y: '16px', 'dominant-basiline': 'middle', 'text-anchor': 'middle' });
 		this.text.textContent = "";
-		
+
 		this.svg.appendChild(this.line);
 		this.svg.appendChild(this.text);
 		this.viewer.containerElement.appendChild(this.svg);
@@ -72,7 +72,7 @@ class ScaleBar extends Units {
 		this.line.setAttribute('x2', this.width - margin/2);
 		this.text.textContent = this.format(s.label);
 	}
-	
+
 
     //find best length for scale from min -> max
 	//zoom 2 means a pixel in image is now 2 pixel on screen, scale is

--- a/src/UIBasic.js
+++ b/src/UIBasic.js
@@ -91,6 +91,7 @@ class UIBasic {
 	 * @param {bool} options.autofit=true Whether the initial position of the camera is set to fit the scene model.
 	 * @param {number} options.priority=0 Higher priority controllers are invoked first.
 	 * @param {{UIBasic#Action}} options.actions An Object of {@link UIBasic#Action}. A set of default actions are ready to be used.
+	 * @param {number} options.pixelSize Spatial resolution: physical size represented by a single pixel in mm
 	 * @param {string} options.attribution Some information related to data attribution or credits.
 	 * @param {Array<UIBasic#MenuEntry>} options.menu The interface menu structure.
 	 * @param {bool} options.enableTooltip=true Whether to enable tool button tooltip.
@@ -126,7 +127,7 @@ class UIBasic {
 			controlZoomMessage: null, //"Use Ctrl + Wheel to zoom instead of scrolling" ,
 			menu: []
 		});
-		
+
 		Object.assign(this, options);
 		if (this.autoFit) //FIXME Check if fitCamera is triggered only if the layer is loaded. Is updateSize the right event?
 			this.viewer.canvas.addEvent('updateSize', () => this.viewer.camera.fitCameraBox(0));
@@ -319,17 +320,28 @@ class UIBasic {
 			*/
 
 			this.setupActions();
-			if(this.pixelSize) 
-				this.scalebar = new ScaleBar(this.pixelSize, this.viewer);
 
-			if(this.attribution) {
+
+			/* Get pixel size from options if provided or from layer metadata
+			 */
+			if(this.pixelSize) {
+				this.scalebar = new ScaleBar(this.pixelSize, this.viewer);
+			}
+			else if(this.viewer.canvas.layers[Object.keys(this.viewer.canvas.layers)[0]].pixelSize) {
+				let pixelSize = this.viewer.canvas.layers[Object.keys(this.viewer.canvas.layers)[0]].pixelSize;
+				this.scalebar = new ScaleBar(pixelSize, this.viewer);
+			}
+
+
+
+		        if(this.attribution) {
 				var p = document.createElement('p');
 				p.classList.add('openlime-attribution');
 				p.innerHTML = this.attribution;
 				this.viewer.containerElement.appendChild(p);
 			}
 
-			
+
 
 			for(let l of Object.values(this.viewer.canvas.layers)) {
 				this.setLayer(l);

--- a/src/UIBasic.js
+++ b/src/UIBasic.js
@@ -328,7 +328,7 @@ class UIBasic {
 				this.scalebar = new ScaleBar(this.pixelSize, this.viewer);
 			}
 			else if(this.viewer.canvas.layers[Object.keys(this.viewer.canvas.layers)[0]].pixelSize) {
-				let pixelSize = this.viewer.canvas.layers[Object.keys(this.viewer.canvas.layers)[0]].pixelSize;
+				let pixelSize = this.viewer.canvas.layers[Object.keys(this.viewer.canvas.layers)[0]].pixelSizePerMM();
 				this.scalebar = new ScaleBar(pixelSize, this.viewer);
 			}
 


### PR DESCRIPTION
These commits add IIPImage support to OpenLime, including support for TIFF stacks for RTI data. The implementation works for both image and RTI image types. An optional `server` parameter can be used to allow an iipsrv endpoint to be specified, in which case the `url` parameter is simply the image file name. Examples have been added to dist/examples.

An update to the scale bar code also adds µm units and allows the resolution to be obtained directly from the image layer.