### PR TITLE
Allow configuring mouse buttons for pan gestures

### DIFF
--- a/src/Controller.js
+++ b/src/Controller.js
@@ -46,7 +46,8 @@ class Controller {
 			panDelay: 50,
 			zoomDelay: 200,
 			priority: 0,
-			activeModifiers: [0]
+			activeModifiers: [0],
+			panMouseButtons: null
 		});
 
 		Object.assign(this, options);
@@ -70,6 +71,35 @@ class Controller {
 		if (e.altKey) state += 4;
 
 		return state;
+	}
+
+	/**
+	 * Checks whether a mouse event matches a configured list of allowed buttons.
+	 * Non-mouse pointers are accepted so touch and pen interactions keep working.
+	 * @param {PointerEvent} e - The pointer event to check
+	 * @param {number[]} [buttons=this.panMouseButtons] - Allowed mouse buttons: 0 left, 1 middle, 2 right
+	 * @returns {boolean} True if the event matches or no mouse-button filter is configured
+	 */
+	matchesMouseButton(e, buttons = this.panMouseButtons) {
+		if ((e.pointerType && e.pointerType !== 'mouse') || !Array.isArray(buttons))
+			return true;
+
+		if (buttons.includes(e.button))
+			return true;
+
+		if (typeof e.buttons === 'number') {
+			const mouseButtonMasks = {
+				0: 1,
+				1: 4,
+				2: 2
+			};
+			return buttons.some(button => {
+				const mask = mouseButtonMasks[button];
+				return mask && (e.buttons & mask) === mask;
+			});
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Controller2D.js
+++ b/src/Controller2D.js
@@ -42,6 +42,7 @@ class Controller2D extends Controller {
 	 * @param {updatePosition} [options.onPanEnd] - Callback for pan end event
 	 * @param {boolean} [options.active=true] - Whether the controller is active
 	 * @param {number[]} [options.activeModifiers=[0]] - Array of active modifier states
+	 * @param {number[]} [options.panMouseButtons] - Mouse buttons allowed to pan: 0 left, 1 middle, 2 right
 	 */
 	constructor(callback, options) {
 		super(options);
@@ -114,7 +115,7 @@ class Controller2D extends Controller {
 	 * @override
 	 */
 	panStart(e) {
-		if (!this.active || !this.activeModifiers.includes(this.modifierState(e)))
+		if (!this.active || !this.activeModifiers.includes(this.modifierState(e)) || !this.matchesMouseButton(e))
 			return;
 
 		if (this.relative) {

--- a/src/ControllerPanZoom.js
+++ b/src/ControllerPanZoom.js
@@ -25,6 +25,7 @@ class ControllerPanZoom extends Controller {
 	 * @param {number} [options.zoomAmount=1.2] - The zoom multiplier for wheel/double-tap events
 	 * @param {boolean} [options.controlZoom=false] - If true, requires Ctrl key to be pressed for zoom operations
 	 * @param {boolean} [options.useGLcoords=false] - If true, uses WebGL coordinate system instead of HTML
+	 * @param {number[]} [options.panMouseButtons] - Mouse buttons allowed to pan: 0 left, 1 middle, 2 right
 	 * @param {number} [options.panDelay] - Delay for pan animations
 	 * @param {number} [options.zoomDelay] - Delay for zoom animations
 	 */
@@ -53,7 +54,7 @@ class ControllerPanZoom extends Controller {
 	 * @param {PointerEvent} e - The pointer event that initiated the pan
 	 */
 	panStart(e) {
-		if (!this.active || this.panning || !this.activeModifiers.includes(this.modifierState(e)))
+		if (!this.active || this.panning || !this.activeModifiers.includes(this.modifierState(e)) || !this.matchesMouseButton(e))
 			return;
 		this.panning = true;
 

--- a/src/UIBasic.js
+++ b/src/UIBasic.js
@@ -179,9 +179,14 @@ class UIBasic {
 		if (this.autoFit) //FIXME Check if fitCamera is triggered only if the layer is loaded. Is updateSize the right event?
 			this.viewer.canvas.addEvent('updateSize', () => this.viewer.camera.fitCameraBox(0));
 
+		let lightLayers = [];
+		for (let [id, layer] of Object.entries(this.viewer.canvas.layers))
+			if (layer.controls.light) lightLayers.push(layer);
+
 		this.panzoom = new ControllerPanZoom(this.viewer.camera, {
 			priority: -1000,
 			activeModifiers: [0, 1],
+			panMouseButtons: lightLayers.length ? [2] : null,
 			controlZoom: this.controlZoomMessage != null
 		});
 		if (this.controlZoomMessage)
@@ -254,6 +259,7 @@ class UIBasic {
 			// TODO: IS THIS OK? It was false before
 			active: false,
 			activeModifiers: [2, 4],
+			panMouseButtons: [0],
 			control: 'light',
 			onPanStart: this.showLightDirections ? () => {
 				Object.values(this.viewer.canvas.layers).filter(l => l.annotations != null).forEach(l => l.setVisible(false));
@@ -269,11 +275,6 @@ class UIBasic {
 		controller.priority = 0;
 		this.viewer.pointerManager.onEvent(controller);
 		this.lightcontroller = controller;
-
-
-		let lightLayers = [];
-		for (let [id, layer] of Object.entries(this.viewer.canvas.layers))
-			if (layer.controls.light) lightLayers.push(layer);
 
 		if (lightLayers.length) {
 			this.createLightDirections();

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -179,6 +179,10 @@ class Viewer {
 		this.pointerManager = new PointerManager(this.overlayElement, { idleTime: this.idleTime });
 
 		// Prevent context menu
+		this.overlayElement.addEventListener('contextmenu', (e) => {
+			e.preventDefault();
+			return false;
+		});
 		this.canvasElement.addEventListener('contextmenu', (e) => {
 			e.preventDefault();
 			return false;


### PR DESCRIPTION
 Summary:
Adds configurable mouse-button filtering for pan gestures.
When a viewer contains light-controllable layers, the default UI can use left mouse drag for light direction control and right mouse drag for camera panning.

Changes:
- Added `panMouseButtons` option to `Controller`.
- Added shared `matchesMouseButton()` helper.
- Updated `ControllerPanZoom` and `Controller2D` to respect `panMouseButtons`.
- Configured `UIBasic` so light control uses left mouse button and camera panning uses right mouse button when light layers are present.
- Prevented the browser context menu on the viewer overlay during right-button interaction.

Compatibility:
The default `panMouseButtons` value is `null`, preserving existing behavior for controllers that do not opt into mouse-button filtering.
